### PR TITLE
feat(v1) traffic light dictionary version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+ignore := 'test*|obj|bin|Release|Debug'
+basePath := ~/projects/personal/interviews/swile
+bin := ./bin/Release/net7.0/TrafficLight
+
+# Usage samples:
+# 
+#   make build 
+#   make publish
+#   make test
+#   make run 
+
+build:
+		@dotnet build TrafficLight.csproj --configuration Release
+
+publish:
+		@dotnet publish TrafficLight.csproj --configuration Release
+
+run:
+		@$(bin)
+
+clean:
+		@cd $(basePath) && rm -rf ./bin ./obj
+
+tree:
+		@tree . -I $(ignore)
+
+all: clean build publish tree run

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,14 @@
+﻿// // See https://aka.ms/new-console-template for more information
+
+using TrafficLight;
+
+var cts = new CancellationTokenSource();
+cts.SetCancelKeyPress();
+
+await DictionaryVersionRunner.Run(cts);
+
+Console.WriteLine($"{Environment.NewLine}Disponsing cancelation source");
+cts.Dispose();
+
+Console.WriteLine("Finishing gracefully");
+Environment.Exit(0);

--- a/TrafficLight.csproj
+++ b/TrafficLight.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TrafficLight.sln
+++ b/TrafficLight.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "swile", "swile.csproj", "{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C05C6E24-8222-484B-8874-8789CC91D916}
+	EndGlobalSection
+EndGlobal

--- a/src/core/ExtensionMethods.cs
+++ b/src/core/ExtensionMethods.cs
@@ -1,0 +1,14 @@
+using System.Text;
+using System.Text.Json;
+
+namespace TrafficLight;
+
+public static class ExtensionMethods {
+    public static void SetCancelKeyPress(this CancellationTokenSource cts) {
+        Console.WriteLine("Setting cancelation handler");
+        Console.CancelKeyPress += (sender, e) => {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+    }
+}

--- a/src/core/settings/TrafficLightSettings.cs
+++ b/src/core/settings/TrafficLightSettings.cs
@@ -1,0 +1,6 @@
+namespace TrafficLight;
+
+public class Settings {
+    public required string State;
+    public required TimeSpan Delay;
+}

--- a/src/instructions.md
+++ b/src/instructions.md
@@ -1,0 +1,8 @@
+# Instructions
+
+Build a class that represents a traffic light in which a simple
+print of a color represents the display of the desired color.
+
+It will have a start method that indicates the beginning of the cycle.
+
+Bonus: stop method that stops the traffic light and allows it to return to where it left off by calling start again.

--- a/src/v1/DictionaryVersion.cs
+++ b/src/v1/DictionaryVersion.cs
@@ -1,0 +1,30 @@
+namespace TrafficLight;
+public static class DictionaryVersionRunner {
+    private static readonly Dictionary<string, Settings> _trafficLight = new() {
+        { "go", new Settings { State = "Green", Delay = TimeSpan.FromSeconds(4) } },
+        { "attention", new Settings { State = "Amber", Delay = TimeSpan.FromSeconds(1) } },
+        { "stop", new Settings { State = "Red", Delay = TimeSpan.FromSeconds(2) } }
+    };
+
+
+    static public async Task Run(CancellationTokenSource cts) {
+        Console.WriteLine($"{Environment.NewLine}DictionaryVersionRunner.Run() execution");
+        await DisplayLight(cts.Token);
+    }
+
+    static async Task DisplayLight(CancellationToken token) {
+        try {
+            Console.WriteLine($"{Environment.NewLine}");
+            while (true) {
+                foreach (var item in _trafficLight) {
+                    Console.SetCursorPosition(0, Console.CursorTop -1);
+                    Console.WriteLine($"{item.Value.State} - {item.Key}{new string(' ', 20)}");
+                    await Task.Delay(item.Value.Delay, token);
+                }
+            }
+        }
+        catch (OperationCanceledException) {
+            Console.WriteLine($"{Environment.NewLine}Operation canceled");
+        }
+    }
+}


### PR DESCRIPTION
# Traffic light dictionary version

In this version a dictionary approach run  traffic light in a loop until cancel key is pressed.

On runner class, a dictionary with `go`, `attention` and `stop` values use a settings class with a `State` and `Delay` properties helping control execution.

Also a extension method class contains `SetCancelKeyPress` to handle cancel key press.
