### PR TITLE
feat(v1) add command line handler and v2 scaffolding

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,7 @@ using TrafficLight;
 var cts = new CancellationTokenSource();
 cts.SetCancelKeyPress();
 
-await DictionaryVersionRunner.Run(cts);
+await CommandLineHandler.Handle(args, cts);
 
 Console.WriteLine($"{Environment.NewLine}Disponsing cancelation source");
 cts.Dispose();

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ _Below is an example of how you can instruct your audience on installing and set
 
 ## Roadmap
 
-- [ ] Add v1 with dictionary version
-- [ ] Add v2 scaffold and a command line handler
+- [x] Add v1 with dictionary version
+- [x] Add v2 scaffold and a command line handler
 - [ ] Add implements v2 with enum approach
     - [ ] basic
     - [ ] starting when it was paused

--- a/TrafficLight.sln
+++ b/TrafficLight.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "swile", "swile.csproj", "{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrafficLight", "TrafficLight.csproj", "{C44A8DC8-AD96-4F70-8E3D-71337DE2559B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/core/CommandLineHandler.cs
+++ b/src/core/CommandLineHandler.cs
@@ -1,0 +1,44 @@
+namespace TrafficLight;
+public static class CommandLineHandler {
+    public static string CommandlineName = "TrafficLight";
+
+    public static async Task Handle(string[] args, CancellationTokenSource cts) {
+        Dictionary<string, string> options = new();
+        options.SetKeysFromArgs(args);
+
+        if (options.ContainsKey("--help") || 
+           !options.ContainsKey("--version")) {
+            ShowHelper();
+        }
+
+        var version = options.GetKey("--version", new string[] { "v1", "v2" });
+        await RunSelectedVersion(version, cts);
+    }
+
+    private static void ShowHelper() {
+        Console.WriteLine($"{Environment.NewLine}Usage: {CommandlineName} [options]");
+        Console.WriteLine($"{Environment.NewLine}Options:");
+        Console.WriteLine("  --help                             Display this help message");
+        Console.WriteLine("  --version=versionNumber            Required: specify implementation version");
+        Console.WriteLine($"{Environment.NewLine}Example:");
+        Console.WriteLine($"  {CommandlineName} --version=v1 {Environment.NewLine}");
+        Console.WriteLine($"Available versions:");
+        Console.WriteLine($" v1 - simple dictionary implementation");
+        Console.WriteLine($" v2 - vehicle, pedestrian and intermitent implementation with enum");
+        Environment.Exit(0);
+    }
+
+    private static async Task RunSelectedVersion(string version, CancellationTokenSource cts) {
+        Dictionary<string, IRunner> options = new() {
+            {"v2", new EnumVersionRunner()},
+            {"v1", new DictionaryVersionRunner()},
+        };
+
+        if (!options.TryGetValue(version, out var result)) {
+            Console.WriteLine($"Version not found");
+            Environment.Exit(1);
+        }
+
+        await result.Run(cts);
+    }
+}

--- a/src/core/ExtensionMethods.cs
+++ b/src/core/ExtensionMethods.cs
@@ -1,6 +1,3 @@
-using System.Text;
-using System.Text.Json;
-
 namespace TrafficLight;
 
 public static class ExtensionMethods {
@@ -10,5 +7,25 @@ public static class ExtensionMethods {
             e.Cancel = true;
             cts.Cancel();
         };
+    }
+
+    public static void SetKeysFromArgs(this Dictionary<string, string> options, string[] args) {
+        foreach (var arg in args) {
+            var keyValue = arg.Split('=');
+            options[keyValue[0]] = keyValue.Length == 2 ? keyValue[1] : string.Empty;
+        }
+    }
+
+    public static string GetKey(this Dictionary<string, string> options, string option, string[] validOption, string defaultValue = "") {
+        if (!options.TryGetValue(option, out string? optionValue))
+            optionValue = defaultValue;
+
+        if (!validOption.Contains(optionValue)) {
+            Console.WriteLine($"{Environment.NewLine}Error:");
+            Console.WriteLine($"  Invalid value - {option} expect: \"{String.Join("\" or \"", validOption)}\" and received \"{optionValue}\"");
+            Environment.Exit(0);
+        }
+
+        return optionValue;
     }
 }

--- a/src/core/IRunner.cs
+++ b/src/core/IRunner.cs
@@ -1,0 +1,5 @@
+namespace TrafficLight;
+
+public interface IRunner {
+    Task Run(CancellationTokenSource cts);
+}

--- a/src/v1/DictionaryVersion.cs
+++ b/src/v1/DictionaryVersion.cs
@@ -1,5 +1,5 @@
 namespace TrafficLight;
-public static class DictionaryVersionRunner {
+public class DictionaryVersionRunner: IRunner {
     private static readonly Dictionary<string, Settings> _trafficLight = new() {
         { "go", new Settings { State = "Green", Delay = TimeSpan.FromSeconds(4) } },
         { "attention", new Settings { State = "Amber", Delay = TimeSpan.FromSeconds(1) } },
@@ -7,12 +7,12 @@ public static class DictionaryVersionRunner {
     };
 
 
-    static public async Task Run(CancellationTokenSource cts) {
+    public async Task Run(CancellationTokenSource cts) {
         Console.WriteLine($"{Environment.NewLine}DictionaryVersionRunner.Run() execution");
         await DisplayLight(cts.Token);
     }
 
-    static async Task DisplayLight(CancellationToken token) {
+    private async Task DisplayLight(CancellationToken token) {
         try {
             Console.WriteLine($"{Environment.NewLine}");
             while (true) {

--- a/src/v2/EnumVersion.cs
+++ b/src/v2/EnumVersion.cs
@@ -1,0 +1,10 @@
+namespace TrafficLight;
+
+public class EnumVersionRunner: IRunner {
+    public async Task Run(CancellationTokenSource cts) {
+        Console.WriteLine($"{Environment.NewLine}EnumVersionRunner.Run() execution");
+
+        await Task.Run(() => Thread.Sleep(1));
+        Console.WriteLine("Version not implemented yet");
+    }
+}


### PR DESCRIPTION
# feat(v1) add command line handler and v2 scaffolding

Add command line handler to handle `v1` and `v2` when `v1` is already implemented dictionary approach, `v1` is just a scaffolding to new implementation not done yet.

Versions are in a `IRunner` dictionary that allow new implementations in a easy way.