### PR TITLE
feat(v2.1) bonus - return to where it left off

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,5 @@
+{
+  "action": "run",
+  "type": "vehicle",
+  "resumedAt": "Green"
+}

--- a/src/core/ExtensionMethods.cs
+++ b/src/core/ExtensionMethods.cs
@@ -1,3 +1,6 @@
+using System.Text;
+using System.Text.Json;
+
 namespace TrafficLight;
 
 public static class ExtensionMethods {
@@ -29,6 +32,21 @@ public static class ExtensionMethods {
         return optionValue;
     }
 
+    public static void Refresh(this ApplicationSettings settings, string filename) {
+        var jsonSettings = File.ReadAllText(filename, Encoding.UTF8);
+
+        if (string.IsNullOrWhiteSpace(jsonSettings)) {
+            return;
+        }
+
+        var content =  JsonSerializer.Deserialize<ApplicationSettings>(jsonSettings);
+        if (content != null) {
+            settings.Type = content.Type;
+            settings.Action = content.Action;
+            settings.ResumedAt = content.ResumedAt;
+        }
+    }
+
     public static CancellationToken GetLinkedTokenSource(this CancellationToken token) {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
         return cts.Token;
@@ -39,5 +57,11 @@ public static class ExtensionMethods {
             Console.WriteLine("Finishing gracefully by Control + C keys");
             Environment.Exit(0);
         }
+    }
+
+    public static void UpdateSettings(this ApplicationSettings settings, string filename) {
+        var options = new JsonSerializerOptions { WriteIndented = true,  };
+        var json = JsonSerializer.Serialize(settings, options);
+        File.WriteAllText(filename, json);
     }
 }

--- a/src/core/settings/ApplicationSettings.cs
+++ b/src/core/settings/ApplicationSettings.cs
@@ -3,6 +3,8 @@ using System.Text.Json.Serialization;
 namespace TrafficLight;
 public class ApplicationSettings
 {
+    public delegate Task RefreshEventHandler(ApplicationSettings s);
+    public static event RefreshEventHandler? RefreshAsync;
     public readonly static string Filename = "settings.json";
 
     [JsonPropertyName("action")]
@@ -16,4 +18,11 @@ public class ApplicationSettings
 
     [JsonPropertyName("resumedAt")]
     public string? ResumedAt { get; set; }
+
+    public void Load() {
+        if (RefreshAsync == null) {
+            throw new Exception("RefreshSettingsAsync handler must be set before");
+        }
+        RefreshAsync(this);
+    }
 }

--- a/src/v2/EnumVersion.cs
+++ b/src/v2/EnumVersion.cs
@@ -2,15 +2,24 @@ namespace TrafficLight;
 public class EnumVersionRunner: IRunner {
     public async Task Run(CancellationTokenSource cts) {
         Console.WriteLine("Setting refresh settings handler");
-
-        var settings = new ApplicationSettings{
-            Action = "run",
-            Type= "vehicle",
+        ApplicationSettings.RefreshAsync += async (e) => {
+            while (!cts.Token.IsCancellationRequested) {
+                e.Refresh(ApplicationSettings.Filename);
+                await Task.Delay(250, cts.Token.GetLinkedTokenSource());
+            }
         };
+
+        var settings = new ApplicationSettings();
+        settings.Load();
 
         while (settings != null && !string.IsNullOrEmpty(settings.Type)) {
             Console.WriteLine($"{settings.Type} is running.");
             await Runner.RunAsync(settings, cts);
+            
+            if (settings.Resume.HasValue && settings.Resume.Value) {
+                settings.UpdateSettings(ApplicationSettings.Filename);
+                break;
+            }
         }
 
     }

--- a/src/v2/TrafficLightRunner.cs
+++ b/src/v2/TrafficLightRunner.cs
@@ -7,7 +7,8 @@ public static class Runner {
     }
 
     public static async Task ValidateSettingsAction(ApplicationSettings settings, CancellationToken token) {
-        await Task.Run(() => ValidateStopAction(settings, token), token);
+        ValidateStopAction(settings, token);
+        await  ValidatePauseAction(settings, token);
     }
 
     private static void ValidateStopAction(ApplicationSettings settings, CancellationToken token) {
@@ -16,5 +17,17 @@ public static class Runner {
             Environment.Exit(0);
         }
         token.ValidateCancellationRequest();
+    }
+
+    private static async Task ValidatePauseAction(ApplicationSettings settings, CancellationToken token) {
+        TimeSpan duration = TimeSpan.FromMilliseconds(250);
+        while (settings.Action?.ToLower() == "pause") {
+            Console.SetCursorPosition(60, Console.CursorTop -1);
+            Console.WriteLine($"{settings.Type} is paused.");
+            token.ValidateCancellationRequest();
+            await Task.Delay(duration, token.GetLinkedTokenSource());
+        }
+        Console.SetCursorPosition(60, Console.CursorTop -1);
+        Console.WriteLine($"                         ");
     }
 }

--- a/src/v2/core/TrafficLightBase.cs
+++ b/src/v2/core/TrafficLightBase.cs
@@ -45,6 +45,8 @@ public class TrafficLightBase {
         Console.WriteLine($"{Environment.NewLine}");
         if (!string.IsNullOrWhiteSpace(settings.ResumedAt)) {
             ResumedAt = $"{settings.ResumedAt}";
+            settings.ResumedAt = null;
+            settings.UpdateSettings(ApplicationSettings.Filename);
         }
     }
 }


### PR DESCRIPTION
# feat(v2.1) bonus - return to where it left off

This implementation contains v2 plus :

 - [x] add settings.json to store state when execution has finished
 - [x] settings refresh handler improvement
 - [x] updates enum version to consider settings state
 
This implementation pull `settings.json` data to update process execution. An future improvement may listen file changes instead of pulling settings file.
