### PR TITLE
feat(v2.2) bonus - allow v2 specify initial state

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ _Below is an example of how you can instruct your audience on installing and set
 - [x] Add v2 scaffold and a command line handler
 - [-] Add implements v2 with enum approach
     - [x] basic
-    - [ ] starting when it was paused
+    - [x] start from it was paused
+    - [x] start passing initial state
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/src/core/CommandLineHandler.cs
+++ b/src/core/CommandLineHandler.cs
@@ -12,23 +12,30 @@ public static class CommandLineHandler {
         }
 
         var version = options.GetKey("--version", new string[] { "v1", "v2" });
-        await RunSelectedVersion(version, cts);
+        var validStates = new string[] { "vehicle", "pedestrian", "intermitent", "" };
+        var state = options.GetKey("--state", validStates);
+        await RunSelectedVersion(version, state, cts);
     }
 
     private static void ShowHelper() {
-        Console.WriteLine($"{Environment.NewLine}Usage: {CommandlineName} [options]");
-        Console.WriteLine($"{Environment.NewLine}Options:");
+        var newLine = Environment.NewLine;
+        Console.WriteLine($"{newLine}Usage: {CommandlineName} [options]");
+        Console.WriteLine($"{newLine}Options:");
         Console.WriteLine("  --help                             Display this help message");
         Console.WriteLine("  --version=versionNumber            Required: specify implementation version");
-        Console.WriteLine($"{Environment.NewLine}Example:");
-        Console.WriteLine($"  {CommandlineName} --version=v1 {Environment.NewLine}");
-        Console.WriteLine($"Available versions:");
-        Console.WriteLine($" v1 - simple dictionary implementation");
-        Console.WriteLine($" v2 - vehicle, pedestrian and intermitent implementation with enum");
+        Console.WriteLine("  --state=stateType                  Optional: specify traffic light state");
+        Console.WriteLine($"{newLine}Examples:");
+        Console.WriteLine($"  {CommandlineName} --version=v1");
+        Console.WriteLine($"  {CommandlineName} --version=v2 --state=vehicle");
+        Console.WriteLine($"{newLine}Available versions:");
+        Console.WriteLine($"  v1 - simple dictionary implementation");
+        Console.WriteLine($"  v2 - vehicle, pedestrian and intermitent implementation with enum");
+        Console.WriteLine($"{newLine}Available states:");
+        Console.WriteLine($"  vehicle, pedestrian or intermitent {newLine}");
         Environment.Exit(0);
     }
 
-    private static async Task RunSelectedVersion(string version, CancellationTokenSource cts) {
+    private static async Task RunSelectedVersion(string version, string state, CancellationTokenSource cts) {
         Dictionary<string, IRunner> options = new() {
             {"v1", new DictionaryVersionRunner()},
             {"v2", new EnumVersionRunner()},
@@ -37,6 +44,11 @@ public static class CommandLineHandler {
         if (!options.TryGetValue(version, out var result)) {
             Console.WriteLine($"Version not found");
             Environment.Exit(1);
+        }
+
+        if (!string.IsNullOrEmpty(state)) {
+            Console.WriteLine($"State {state} received");
+            result.SetInitialState(state, cts);
         }
 
         await result.Run(cts);

--- a/src/core/IRunner.cs
+++ b/src/core/IRunner.cs
@@ -2,4 +2,5 @@ namespace TrafficLight;
 
 public interface IRunner {
     Task Run(CancellationTokenSource cts);
+    void SetInitialState(string state, CancellationTokenSource cts);
 }

--- a/src/v1/DictionaryVersion.cs
+++ b/src/v1/DictionaryVersion.cs
@@ -12,6 +12,10 @@ public class DictionaryVersionRunner: IRunner {
         await DisplayLight(cts.Token);
     }
 
+    public void SetInitialState(string type, CancellationTokenSource cts) {
+        Console.WriteLine($"{Environment.NewLine}DictionaryVersionRunner not implements state execution control");
+    }
+
     private async Task DisplayLight(CancellationToken token) {
         try {
             Console.WriteLine($"{Environment.NewLine}");

--- a/src/v2/EnumVersion.cs
+++ b/src/v2/EnumVersion.cs
@@ -1,26 +1,48 @@
 namespace TrafficLight;
 public class EnumVersionRunner: IRunner {
-    public async Task Run(CancellationTokenSource cts) {
+    private string InitialState = string.Empty;
+    
+    public async Task Run(CancellationTokenSource cts)
+    {
         Console.WriteLine("Setting refresh settings handler");
+        var settings = GetApplicationSettings();
+
+        SetApplicationSettingsRefreshAsync(cts);
+        settings.Load();
+
+        while (settings != null && !string.IsNullOrEmpty(settings.Type)) {
+            Console.WriteLine($"{settings.Type} is running.");
+            await Runner.RunAsync(settings, cts);
+
+            if (settings.Resume.HasValue && settings.Resume.Value) {
+                settings.UpdateSettings(ApplicationSettings.Filename);
+                break;
+            }
+        }
+    }
+
+    public void SetInitialState(string state, CancellationTokenSource cts) {
+        InitialState = state;
+    }
+
+    private ApplicationSettings GetApplicationSettings() {
+        var settings = new ApplicationSettings();
+
+        if (!string.IsNullOrEmpty(InitialState)) {
+            settings.Type = InitialState;
+            settings.ResumedAt = string.Empty;
+            settings.UpdateSettings(ApplicationSettings.Filename);
+        }
+
+        return settings;
+    }
+
+    private static void SetApplicationSettingsRefreshAsync(CancellationTokenSource cts) {
         ApplicationSettings.RefreshAsync += async (e) => {
             while (!cts.Token.IsCancellationRequested) {
                 e.Refresh(ApplicationSettings.Filename);
                 await Task.Delay(250, cts.Token.GetLinkedTokenSource());
             }
         };
-
-        var settings = new ApplicationSettings();
-        settings.Load();
-
-        while (settings != null && !string.IsNullOrEmpty(settings.Type)) {
-            Console.WriteLine($"{settings.Type} is running.");
-            await Runner.RunAsync(settings, cts);
-            
-            if (settings.Resume.HasValue && settings.Resume.Value) {
-                settings.UpdateSettings(ApplicationSettings.Filename);
-                break;
-            }
-        }
-
     }
 }


### PR DESCRIPTION
# feat(v2.2) bonus - allow v2 specify initial state

This implementation contains:

 - [x] implementation using enum instead of dictionary
 - [x] implements vehicle, pedestrian and intermitent traffic lights
 - [x] use factory to get desired implementation
 - [x] allow set intial state on v2 implementation
 